### PR TITLE
support double accidentals

### DIFF
--- a/Sources/Tonic/ChordTable.swift
+++ b/Sources/Tonic/ChordTable.swift
@@ -15,7 +15,7 @@ class ChordTable {
     }
 
     static func generateChords(type: ChordType, _ r: inout [Int: Chord]) {
-        let accidentals: [Accidental] = [.flat, .natural, .sharp]
+        let accidentals: [Accidental] = [.doubleFlat, .flat, .natural, .sharp, .doubleSharp]
         for accidental in accidentals {
             for letter in Letter.allCases {
                 let root = NoteClass(letter, accidental: accidental)

--- a/Tests/TonicTests/KeyTests.swift
+++ b/Tests/TonicTests/KeyTests.swift
@@ -35,6 +35,9 @@ class KeyTests: XCTestCase {
 
         XCTAssertEqual(Key(root: .Db, scale: .phrygian).primaryTriads.map { $0.description },
                        ["D♭m", "E𝄫", "F♭", "G♭m", "A♭°", "B𝄫", "C♭m"])
+
+        XCTAssertEqual(Key(root: .Ds, scale: .harmonicMinor).primaryTriads.map { $0.description },
+                       ["D♯m", "E♯°", "F♯⁺", "G♯m", "A♯", "B", "C𝄪°"])
     }
 
     func testKeyChords() {

--- a/Tests/TonicTests/KeyTests.swift
+++ b/Tests/TonicTests/KeyTests.swift
@@ -32,6 +32,9 @@ class KeyTests: XCTestCase {
     func testScalePrimaryTriads() {
         XCTAssertEqual(Key(root: .C, scale: .harmonicMinor).primaryTriads.map { $0.description },
                        ["Cm", "D°", "E♭⁺", "Fm", "G", "A♭", "B°"])
+
+        XCTAssertEqual(Key(root: .Db, scale: .phrygian).primaryTriads.map { $0.description },
+                       ["D♭m", "E𝄫", "F♭", "G♭m", "A♭°", "B𝄫", "C♭m"])
     }
 
     func testKeyChords() {


### PR DESCRIPTION
As discussed with @aure in #6, this PR adds support for double flats and double sharps in chord generation.