### PR TITLE
rename phrygian major to phrygian dominant

### DIFF
--- a/Sources/Tonic/Scale+Shortcuts.swift
+++ b/Sources/Tonic/Scale+Shortcuts.swift
@@ -12,7 +12,7 @@ public extension Scale {
     static let minor = Scale(intervals: Scale.aeolian.intervals, description: "Minor")
 
     /// Harmonic minor scale
-    static let harmonicMinor = Scale(intervals: [.P1, .P1, .M2, .m3, .P4, .P5, .m6, .M7], description: "Harmonic Minor")
+    static let harmonicMinor = Scale(intervals: [.P1, .M2, .m3, .P4, .P5, .m6, .M7], description: "Harmonic Minor")
 
     /// Melodic minor scale
     static let melodicMinor = Scale(intervals: [.P1, .M2, .m3, .P4, .P5, .M6, .M7], description: "Melodic Minor")
@@ -197,9 +197,6 @@ public extension Scale {
     /// Lydian ♭7 scale
     static let lydianFlat7 = Scale(intervals: [.P1, .M2, .M3, .d5, .P5, .M6, .m7], description: "Lydian ♭7")
 
-    /// Phrygian Major scale
-    static let phrygianMajor = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .M7], description: "Phrygian Major")
-
     /// Phrygian Dominant scale
     static let phrygianDominant = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7], description: "Phrygian Dominant")
 
@@ -363,7 +360,7 @@ extension Scale: CaseIterable {
             .mixolydianFlat2,
             .mixolydianFlat6,
             .phrygian,
-            .phrygianMajor,
+            .phrygianDominant,
             .phrygianFlat4,
             .ultraphrygian,
             .lydian,

--- a/Sources/Tonic/Scale+Shortcuts.swift
+++ b/Sources/Tonic/Scale+Shortcuts.swift
@@ -198,7 +198,10 @@ public extension Scale {
     static let lydianFlat7 = Scale(intervals: [.P1, .M2, .M3, .d5, .P5, .M6, .m7], description: "Lydian ♭7")
 
     /// Phrygian Major scale
-    static let phrygianMajor = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7], description: "Phrygian Major")
+    static let phrygianMajor = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .M7], description: "Phrygian Major")
+
+    /// Phrygian Dominant scale
+    static let phrygianDominant = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7], description: "Phrygian Dominant")
 
     /// Mixolydian ♭6 scale
     static let mixolydianFlat6 = Scale(intervals: [.P1, .M2, .M3, .P4, .P5, .m6, .m7], description: "Mixolydian ♭6")

--- a/Sources/Tonic/Scale+Shortcuts.swift
+++ b/Sources/Tonic/Scale+Shortcuts.swift
@@ -198,7 +198,8 @@ public extension Scale {
     static let lydianFlat7 = Scale(intervals: [.P1, .M2, .M3, .d5, .P5, .M6, .m7], description: "Lydian ♭7")
 
     /// Phrygian Dominant scale
-    static let phrygianDominant = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7], description: "Phrygian Dominant")
+    static let phrygianDominant = Scale(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7],
+                                        description: "Phrygian Dominant")
 
     /// Mixolydian ♭6 scale
     static let mixolydianFlat6 = Scale(intervals: [.P1, .M2, .M3, .P4, .P5, .m6, .m7], description: "Mixolydian ♭6")

--- a/Tests/TonicTests/ScaleTests.swift
+++ b/Tests/TonicTests/ScaleTests.swift
@@ -13,6 +13,7 @@ final class ScaleTests: XCTestCase {
         XCTAssertEqual(Scale.locrian.intervals, [.P1, .m2, .m3, .P4, .d5, .m6, .m7])
         XCTAssertEqual(Scale.chromatic.intervals, [.P1, .m2, .M2, .m3, .M3, .P4, .d5, .P5, .m6, .M6, .m7, .M7])
 
+        XCTAssertEqual(Scale.harmonicMinor.intervals, [.P1, .M2, .m3, .P4, .P5, .m6, .M7])
         XCTAssertEqual(Scale.phrygianDominant.intervals, [.P1, .m2, .M3, .P4, .P5, .m6, .m7])
 
         XCTAssertTrue(Scale.pentatonicMinor.isSubset(of: Scale.blues))

--- a/Tests/TonicTests/ScaleTests.swift
+++ b/Tests/TonicTests/ScaleTests.swift
@@ -13,7 +13,6 @@ final class ScaleTests: XCTestCase {
         XCTAssertEqual(Scale.locrian.intervals, [.P1, .m2, .m3, .P4, .d5, .m6, .m7])
         XCTAssertEqual(Scale.chromatic.intervals, [.P1, .m2, .M2, .m3, .M3, .P4, .d5, .P5, .m6, .M6, .m7, .M7])
 
-        XCTAssertEqual(Scale.phrygianMajor.intervals, [.P1, .m2, .M3, .P4, .P5, .m6, .M7])
         XCTAssertEqual(Scale.phrygianDominant.intervals, [.P1, .m2, .M3, .P4, .P5, .m6, .m7])
 
         XCTAssertTrue(Scale.pentatonicMinor.isSubset(of: Scale.blues))

--- a/Tests/TonicTests/ScaleTests.swift
+++ b/Tests/TonicTests/ScaleTests.swift
@@ -13,6 +13,9 @@ final class ScaleTests: XCTestCase {
         XCTAssertEqual(Scale.locrian.intervals, [.P1, .m2, .m3, .P4, .d5, .m6, .m7])
         XCTAssertEqual(Scale.chromatic.intervals, [.P1, .m2, .M2, .m3, .M3, .P4, .d5, .P5, .m6, .M6, .m7, .M7])
 
+        XCTAssertEqual(Scale.phrygianMajor.intervals, [.P1, .m2, .M3, .P4, .P5, .m6, .M7])
+        XCTAssertEqual(Scale.phrygianDominant.intervals, [.P1, .m2, .M3, .P4, .P5, .m6, .m7])
+
         XCTAssertTrue(Scale.pentatonicMinor.isSubset(of: Scale.blues))
         XCTAssertTrue(Scale.pentatonicMinor.isSubset(of: Scale.minor))
         XCTAssertFalse(Scale.blues.isSubset(of: Scale.minor))


### PR DESCRIPTION
Hello, sorry for the direct PR but it was hard to write a breaking test for and the bug report didn't really make sense.

**Background**
I noticed "phrygian dominant" was missing, but I could see "phrygian major" and it had the right intervals.  I understand this name (the 3rd is major rather than minor), but it is not widely used (I struggled to find any music theory reference with this name).  

There is also a major version of phrygian with a major 7th, but this is double harmonic minor (aka Byzantine and Flamenco) and is already in the codebase.

References:
* https://www.londonguitarinstitute.co.uk/the-phrygian-dominant-scale/

**Change**
* Remove phrygian major, add phrygian dominant
* Minor fix to remove extra P1 interval from harmonic minor

**Versioning**
This is a breaking change so will need to bump major (at time of writing this means the new version would be 2.0.0).

An alternative would be to add `phrygianDominant` and keep `phrygianMajor`, perhaps marking it as deprecated.
