### PR TITLE
Added additional ChordType chords and tests

### DIFF
--- a/Sources/Tonic/ChordType.swift
+++ b/Sources/Tonic/ChordType.swift
@@ -82,6 +82,9 @@ public enum ChordType: Int, CaseIterable {
     /// Minor Eleventh: Minor Third, Perfect Fifth, Minor Seventh, Major Ninth, Perfect Eleventh
     case minorEleventh
 
+    /// Half Diminished Ninth: Minor Third, Diminished Fifth, Minor Seventh, Minor Ninth, Perfect Eleventh
+    case halfDiminishedEleventh
+
     /// Minor Seventh Flat Fifth: Major Third, Diminished Fifth, Major Seventh
     case majorSeventhFlatFifth
 
@@ -112,6 +115,21 @@ public enum ChordType: Int, CaseIterable {
     /// Minor Thirteenth: Major Third, Perfect Fifth, Major Seventh, Major Ninth, Perfect Eleventh, Perfect Thirteenth
     case minorThirteenth
 
+    /// Minor Seventh Flat Ninth Add Eleventh: Minor Third, Perfect Fifth, Minor Seventh, Minor Ninth, Perfect Eleventh, Diminished Thirteenth
+    case minorFlatThirteenthFlatNinth
+
+    /// Major Ninth Sharp Eleventh: Major Third, Perfect Fifth, Major Seventh, Major Ninth, Augmented Eleventh, Perfect Thirteenth
+    case majorThirteenthSharpEleventh
+
+    /// Dominant Eleventh: Major Third, Perfect Fifth, Minor Seventh, Major Ninth, Perfect Eleventh, Perfect Thirteenth
+    case dominantThirteenth
+
+    /// Minor Eleventh: Minor Third, Perfect Fifth, Minor Seventh, Major Ninth, Perfect Eleventh, Diminished Thirteenth
+    case minorEleventhFlatThirteenth
+
+    /// Half Diminished Ninth: Minor Third, Diminished Fifth, Minor Seventh, Minor Ninth, Perfect Eleventh, Diminished Thirteenth
+    case halfDiminishedFlatThirteenth
+
     public var intervals: [Interval] {
         switch self {
         case .majorTriad:                       return [.M3, .P5]
@@ -140,6 +158,7 @@ public enum ChordType: Int, CaseIterable {
         case .majorEleventh:                    return [.M3, .P5, .M7, .M9, .P11]
         case .dominantEleventh:                 return [.M3, .P5, .m7, .M9, .P11]
         case .minorEleventh:                    return [.m3, .P5, .m7, .M9, .P11]
+        case .halfDiminishedEleventh:           return [.m3, .d5, .m7, .m9, .P11]
         case .majorSeventhFlatFifth:            return [.M3, .d5, .M7]
         case .minorSeventhSharpFifth:           return [.M3, .A5, .M7]
         case .majorNinthSharpEleventh:          return [.M3, .P5, .M7, .M9, .A11]
@@ -150,6 +169,11 @@ public enum ChordType: Int, CaseIterable {
         case .minorSeventhFlatNinthAddEleventh: return [.m3, .P5, .m7, .m9, .P11]
         case .majorThirteenth:                  return [.M3, .P5, .M7, .M9, .P11, .P13]
         case .minorThirteenth:                  return [.m3, .P5, .m7, .M9, .P11, .P13]
+        case .minorFlatThirteenthFlatNinth:     return [.m3, .P5, .m7, .m9, .P11, .d13]
+        case .majorThirteenthSharpEleventh:     return [.M3, .P5, .M7, .M9, .A11, .P13]
+        case .dominantThirteenth:               return [.M3, .P5, .m7, .M9, .P11, .P13]
+        case .minorEleventhFlatThirteenth:      return [.m3, .P5, .m7, .M9, .P11, .d13]
+        case .halfDiminishedFlatThirteenth:     return [.m3, .d5, .m7, .m9, .P11, .d13]
         }
     }
 }
@@ -184,6 +208,7 @@ extension ChordType: CustomStringConvertible {
         case .majorEleventh:                    return "maj11"
         case .dominantEleventh:                 return "11"
         case .minorEleventh:                    return "m11"
+        case .halfDiminishedEleventh:           return "(1/2)°11"
         case .majorSeventhFlatFifth:            return "Maj7♭5"
         case .minorSeventhSharpFifth:           return "Maj7♯5"
         case .majorNinthSharpEleventh:          return "maj9♯11"
@@ -194,6 +219,11 @@ extension ChordType: CustomStringConvertible {
         case .minorSeventhFlatNinthAddEleventh: return "m7♭9(add11)"
         case .majorThirteenth:                  return "maj13"
         case .minorThirteenth:                  return "m13"
+        case .minorFlatThirteenthFlatNinth:     return "m♭13♭9"
+        case .majorThirteenthSharpEleventh:     return "maj13♯11"
+        case .dominantThirteenth:               return "13"
+        case .minorEleventhFlatThirteenth:      return "m11♭13"
+        case .halfDiminishedFlatThirteenth:     return "(1/2)°♭13"
         }
     }
 }

--- a/Sources/Tonic/Interval.swift
+++ b/Sources/Tonic/Interval.swift
@@ -80,6 +80,9 @@ public enum Interval: Int, CaseIterable {
     /// Perfect Thirteenth
     case P13
 
+    /// Diminished Thirteenth
+    case d13
+
     /// Number of semitones the interval spans
     public var semitones: Int {
         switch self {
@@ -106,6 +109,7 @@ public enum Interval: Int, CaseIterable {
         case .d11: return 16
         case .P11: return 17
         case .A11: return 18
+        case .d13: return 20
         case .P13: return 21
         }
     }
@@ -136,6 +140,7 @@ public enum Interval: Int, CaseIterable {
         case .d11: return 11
         case .P11: return 11
         case .A11: return 11
+        case .d13: return 13
         case .P13: return 13
         }
     }
@@ -193,6 +198,7 @@ extension Interval: CustomStringConvertible {
         case .d11: return "d11"
         case .P11: return "P11"
         case .A11: return "A11"
+        case .d13: return "d13"
         case .P13: return "P13"
         }
     }
@@ -223,6 +229,7 @@ extension Interval: CustomStringConvertible {
         case .d11: return "Diminished Eleventh"
         case .P11: return "Perfect Eleventh"
         case .A11: return "Augmented Eleventh"
+        case .d13: return "Diminished Thirteenth"
         case .P13: return "Perfect Thirteenth"
         }
     }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -81,7 +81,7 @@ class ChordTests: XCTestCase {
 
         let G11 = Chord(notes: [.G, .B, .D, .F, .A, .C])
         XCTAssertEqual(G11?.description, "G11")
-        
+
         let BhalfDiminished11NoteSet = NoteSet(notes: [.B, .D, .F, .A, .C, .E])
         let chords = ChordTable.shared.getAllChordsForNoteSet(BhalfDiminished11NoteSet)
         XCTAssertTrue(chords.contains(where: { $0.description == "B(1/2)°11" }))

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -81,6 +81,10 @@ class ChordTests: XCTestCase {
 
         let G11 = Chord(notes: [.G, .B, .D, .F, .A, .C])
         XCTAssertEqual(G11?.description, "G11")
+        
+        let BhalfDiminished11NoteSet = NoteSet(notes: [.B, .D, .F, .A, .C, .E])
+        let chords = ChordTable.shared.getAllChordsForNoteSet(BhalfDiminished11NoteSet)
+        XCTAssertTrue(chords.contains(where: { $0.description == "B(1/2)°11" }))
     }
 
     func testThirteenthNaming() {
@@ -88,6 +92,10 @@ class ChordTests: XCTestCase {
         let chords = ChordTable.shared.getAllChordsForNoteSet(noteSet13)
         XCTAssertTrue(chords.contains(where: { $0.description == "Cmaj13" }))
         XCTAssertTrue(chords.contains(where: { $0.description == "Dm13" }))
+        XCTAssertTrue(chords.contains(where: { $0.description == "Em♭13♭9" }))
+        XCTAssertTrue(chords.contains(where: { $0.description == "Fmaj13♯11" }))
+        XCTAssertTrue(chords.contains(where: { $0.description == "Am11♭13" }))
+        XCTAssertTrue(chords.contains(where: { $0.description == "B(1/2)°♭13" }))
     }
 
     func testInversions() {

--- a/Tests/TonicTests/KeyTests.swift
+++ b/Tests/TonicTests/KeyTests.swift
@@ -41,7 +41,7 @@ class KeyTests: XCTestCase {
     }
 
     func testKeyChords() {
-        XCTAssertEqual(Key.G.chords.count, 41)
+        XCTAssertEqual(Key.G.chords.count, 42)
         for triad in Key.G.primaryTriads {
             XCTAssert(Key.G.chords.contains(triad))
         }

--- a/Tests/TonicTests/ReadMeTests.swift
+++ b/Tests/TonicTests/ReadMeTests.swift
@@ -16,12 +16,12 @@ final class ReadMeTests: XCTestCase {
 
     // What chords are in this key?
     func testChordsInKey() {
-        XCTAssertEqual(Key.Cm.chords.count, 41)
+        XCTAssertEqual(Key.Cm.chords.count, 42)
     }
 
     // What chords in this key contain this note?
     func testChordsInKeyContainNote() {
-        XCTAssertEqual(Key.C.chords.filter { $0.noteClasses.contains(.C) }.count, 25)
+        XCTAssertEqual(Key.C.chords.filter { $0.noteClasses.contains(.C) }.count, 26)
     }
 
     // What notes do these keys have in common?


### PR DESCRIPTION
With these additional chords, we can now play an eleventh or thirteenth chord by stacking thirds starting on any degree of the major scale.

In other words, any of the chords (1-7) can now play an eleventh or thirteenth chord and remain in key (for the church modes).

I did my best with choosing names for these chords, but would happily humor any alternatives.