### PR TITLE
added new pitch and notes helper function

### DIFF
--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -156,13 +156,13 @@ extension Chord {
     public func notes(octave: Int) -> [Note] {
         var notes = noteClasses.map {
             Note($0.letter, accidental: $0.accidental, octave: octave)
-        }.sorted()
+        }
 
         for step in 0..<inversion {
             let index = step % notes.count
             notes[index].octave += 1
         }
 
-        return notes
+        return notes.sorted()
     }
 }

--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -128,7 +128,6 @@ extension Chord: CustomStringConvertible {
 }
 
 extension Chord {
-    
     public static func getRankedChords(from notes: [Note]) -> [Chord] {
         let potentialChords = ChordTable.shared.getAllChordsForNoteSet(NoteSet(notes: notes))
         let orderedNotes = notes.sorted(by: { f, s in  f.noteNumber < s.noteNumber })
@@ -140,5 +139,30 @@ extension Chord {
         let sortedRanks = ranks.sorted(by: { $0.0 < $1.0 })
             
         return sortedRanks.map({ $0.1 })
+    }
+}
+
+extension Chord {
+    /// Returns all Pitches of a certain chord, taking into account the inversion, starting at the given octave
+    /// - Parameter octave: octave of the chord for inversion 0
+    /// - Returns: All pitches in that Chord
+    public func pitches(octave: Int) -> [Pitch] {
+        return notes(octave: octave).map { $0.pitch }
+    }
+
+    /// Returns all Notes of a certain chord, taking into account the inversion, starting at the given octave
+    /// - Parameter octave: initial octave of the chord for inversion 0
+    /// - Returns: All notes in that chord
+    public func notes(octave: Int) -> [Note] {
+        var notes = noteClasses.map {
+            Note($0.letter, accidental: $0.accidental, octave: octave)
+        }.sorted()
+
+        for step in 0..<inversion {
+            let index = step % notes.count
+            notes[index].octave += 1
+        }
+
+        return notes
     }
 }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -145,49 +145,80 @@ class ChordTests: XCTestCase {
     func testPitchesWithNoInversion() {
         // Arrange
         let chord = Chord(.C, type: .majorTriad, inversion: 0)
-        let expectedPitches = [Note(.C, octave: 0), Note(.E, octave: 0), Note(.G, octave: 0)].map { $0.pitch }
+        let expectedPitches = [
+            Note(.C, octave: 0),
+            Note(.E, octave: 0),
+            Note(.G, octave: 0)
+        ].map { $0.pitch }
 
         // Act
         let pitches = chord.pitches(octave: 0)
 
         // Assert
-        XCTAssertEqual(pitches, expectedPitches, "Pitches should match expected pitches for no inversion")
+        XCTAssertEqual(
+            pitches,
+            expectedPitches,
+            "Pitches should match expected pitches for no inversion"
+        )
     }
 
     func testPitchesWithInversion() {
         // Arrange
         let chord = Chord(.C, type: .majorTriad, inversion: 1)
-        let expectedPitches = [Note(.E, octave: 4), Note(.G, octave: 4), Note(.C, octave: 5)].map { $0.pitch }
-
+        let expectedPitches = [
+            Note(.E, octave: 4),
+            Note(.G, octave: 4),
+            Note(.C, octave: 5)
+        ].map { $0.pitch }
 
         // Act
         let pitches = chord.pitches(octave: 4)
 
         // Assert
-        XCTAssertEqual(pitches.sorted(), expectedPitches.sorted(), "Pitches should match expected pitches for 1st inversion")
+        XCTAssertEqual(
+            pitches.sorted(),
+            expectedPitches.sorted(),
+            "Pitches should match expected pitches for 1st inversion"
+        )
     }
 
     func testNotesWithNoInversion() {
         // Arrange
         let chord = Chord(.C, type: .majorTriad, inversion: 0)
-        let expectedNotes = [Note(.C, octave: 4), Note(.E, octave: 4), Note(.G, octave: 4)]
+        let expectedNotes = [
+            Note(.C, octave: 4),
+            Note(.E, octave: 4),
+            Note(.G, octave: 4)
+        ]
 
         // Act
         let notes = chord.notes(octave: 4)
 
         // Assert
-        XCTAssertEqual(notes, expectedNotes, "Notes should match expected notes for no inversion")
+        XCTAssertEqual(
+            notes,
+            expectedNotes,
+            "Notes should match expected notes for no inversion"
+        )
     }
 
     func testNotesWithInversion() {
         // Arrange
         let chord = Chord(.C, type: .majorTriad, inversion: 1)
-        let expectedNotes = [Note(.E, octave: 4), Note(.G, octave: 4), Note(.C, octave: 5)].sorted()
+        let expectedNotes = [
+            Note(.E, octave: 4),
+            Note(.G, octave: 4),
+            Note(.C, octave: 5)
+        ]
 
         // Act
         let notes = chord.notes(octave: 4)
 
         // Assert
-        XCTAssertEqual(notes.sorted(), expectedNotes.sorted(), "Notes should match expected notes for 1st inversion")
+        XCTAssertEqual(
+            notes.sorted(),
+            expectedNotes.sorted(),
+            "Notes should match expected notes for 1st inversion"
+        )
     }
 }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -140,8 +140,54 @@ class ChordTests: XCTestCase {
         // should return the same array, in reversed order
         XCTAssertEqual(gChords.map { $0.description }, ["Gsus4", "Csus2"])
         XCTAssertEqual(cChords.map { $0.description }, ["Csus2", "Gsus4"])
-        
-        
-        
+    }
+
+    func testPitchesWithNoInversion() {
+        // Arrange
+        let chord = Chord(.C, type: .majorTriad, inversion: 0)
+        let expectedPitches = [Note(.C, octave: 0), Note(.E, octave: 0), Note(.G, octave: 0)].map { $0.pitch }
+
+        // Act
+        let pitches = chord.pitches(octave: 0)
+
+        // Assert
+        XCTAssertEqual(pitches, expectedPitches, "Pitches should match expected pitches for no inversion")
+    }
+
+    func testPitchesWithInversion() {
+        // Arrange
+        let chord = Chord(.C, type: .majorTriad, inversion: 1)
+        let expectedPitches = [Note(.E, octave: 4), Note(.G, octave: 4), Note(.C, octave: 5)].map { $0.pitch }
+
+
+        // Act
+        let pitches = chord.pitches(octave: 4)
+
+        // Assert
+        XCTAssertEqual(pitches.sorted(), expectedPitches.sorted(), "Pitches should match expected pitches for 1st inversion")
+    }
+
+    func testNotesWithNoInversion() {
+        // Arrange
+        let chord = Chord(.C, type: .majorTriad, inversion: 0)
+        let expectedNotes = [Note(.C, octave: 4), Note(.E, octave: 4), Note(.G, octave: 4)]
+
+        // Act
+        let notes = chord.notes(octave: 4)
+
+        // Assert
+        XCTAssertEqual(notes, expectedNotes, "Notes should match expected notes for no inversion")
+    }
+
+    func testNotesWithInversion() {
+        // Arrange
+        let chord = Chord(.C, type: .majorTriad, inversion: 1)
+        let expectedNotes = [Note(.E, octave: 4), Note(.G, octave: 4), Note(.C, octave: 5)].sorted()
+
+        // Act
+        let notes = chord.notes(octave: 4)
+
+        // Assert
+        XCTAssertEqual(notes.sorted(), expectedNotes.sorted(), "Notes should match expected notes for 1st inversion")
     }
 }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -176,8 +176,8 @@ class ChordTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(
-            pitches.sorted(),
-            expectedPitches.sorted(),
+            pitches,
+            expectedPitches,
             "Pitches should match expected pitches for 1st inversion"
         )
     }
@@ -216,8 +216,8 @@ class ChordTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(
-            notes.sorted(),
-            expectedNotes.sorted(),
+            notes,
+            expectedNotes,
             "Notes should match expected notes for 1st inversion"
         )
     }


### PR DESCRIPTION
### Description

Currently it is impossible to extract the correct notes and their respective octaves from a chord object for a specific inversion.

I tried to obtain the correct notes and pitches for a chord by mapping all the note classes, since it was the only property available in the chord object.
I used the following code: 

```swift
chord.noteClasses.map {
    Note($0.letter, accidental: $0.accidental, octave: 0).pitch
}
```

Unfortunately, the noteClasses do not contain the octave information, making it impossible for me to obtain the correct pitches for a specific chord inversion.

### Proposed Solution

I would like to be able to do something like this:

```swift
chord.pitches(octave: 1) // Return the correct pitches taking into account the inversion
```

```swift
chord.notes(octave: 1) // Return the correct notes taking into account the inversion
```