### PR TITLE
getRankedChords() now removes duplicate non accidental chords

### DIFF
--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -140,7 +140,12 @@ extension Chord {
             sharpNotes.append(Note(pitch: pitch, key: .C))
         }
         returnArray.append(contentsOf: Chord.getRankedChords(from: sharpNotes))
-        returnArray.append(contentsOf: Chord.getRankedChords(from: flatNotes))
+        
+        for chord in Chord.getRankedChords(from: flatNotes) {
+            if !returnArray.contains(chord) {
+                returnArray.append(chord)
+            }
+        }
         
         return returnArray
     }

--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -128,6 +128,24 @@ extension Chord: CustomStringConvertible {
 }
 
 extension Chord {
+    
+    /// Get chords that match a set of pitches, listing enharmonic chords with sharp before flats
+    public static func getRankedChords(from pitchSet: PitchSet) -> [Chord] {
+        var flatNotes: [Note] = []
+        var sharpNotes: [Note] = []
+        var returnArray: [Chord] = []
+        
+        for pitch in pitchSet.array {
+            flatNotes.append(Note(pitch: pitch, key: .F))
+            sharpNotes.append(Note(pitch: pitch, key: .C))
+        }
+        returnArray.append(contentsOf: Chord.getRankedChords(from: sharpNotes))
+        returnArray.append(contentsOf: Chord.getRankedChords(from: flatNotes))
+        
+        return returnArray
+    }
+    /// Get chords from actual notes (spelling matters, C# F G# will not return a C# major)
+    /// Use pitch set version of this function for all enharmonic chords
     public static func getRankedChords(from notes: [Note]) -> [Chord] {
         let potentialChords = ChordTable.shared.getAllChordsForNoteSet(NoteSet(notes: notes))
         let orderedNotes = notes.sorted(by: { f, s in  f.noteNumber < s.noteNumber })

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -148,6 +148,13 @@ class ChordTests: XCTestCase {
         let chords = Chord.getRankedChords(from: fSharp)
         XCTAssertEqual(chords.map { $0.description }, ["F♯", "G♭"])
     }
+    
+    func testDuplicateRankedChords() {
+        let midiNotes: [Int8] = [60, 64, 67]
+        let pitchSet = PitchSet(pitches: midiNotes.map { Pitch($0) } )
+        let cChords = Chord.getRankedChords(from: pitchSet)
+        XCTAssertEqual(cChords.map { $0.description }, ["C"])
+    }
 
     func testPitchesWithNoInversion() {
         // Arrange

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -141,6 +141,13 @@ class ChordTests: XCTestCase {
         XCTAssertEqual(gChords.map { $0.description }, ["Gsus4", "Csus2"])
         XCTAssertEqual(cChords.map { $0.description }, ["Csus2", "Gsus4"])
     }
+    
+    func testEnharmonicChords() {
+        let midiNotes: [Int8] = [54, 58, 61]
+        let fSharp =  PitchSet(pitches: midiNotes.map { Pitch($0) } )
+        let chords = Chord.getRankedChords(from: fSharp)
+        XCTAssertEqual(chords.map { $0.description }, ["F♯", "G♭"])
+    }
 
     func testPitchesWithNoInversion() {
         // Arrange


### PR DESCRIPTION
Chords without an accidental root note (like C major, D Major, etc...) will not be duplicated in `getRankedChords(from pitchSet: pitchSet)`