### PR TITLE
Fix bug "If shiftup results in b#, octave is wrong"

### DIFF
--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -110,13 +110,15 @@ public struct Note: Equatable, Hashable, Codable {
     public func shiftDown(_ shift: Interval) -> Note? {
         var newNote = Note(.C, accidental: .natural, octave: 0)
         var newLetterIndex = (noteClass.letter.rawValue - (shift.degree - 1))
-        let newOctave = (Int(pitch.midiNoteNumber) - shift.semitones) / 12 - 1
+        var carrying = 0
 
         while newLetterIndex < 0 {
             newLetterIndex += 7
+            carrying -= 1
         }
 
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
+        let newOctave = calculateOctave(newLetter: newLetter, carrying: carrying)
         for accidental in Accidental.allCases {
             newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) - shift.semitones) % 12) {
@@ -133,7 +135,7 @@ public struct Note: Equatable, Hashable, Codable {
         var newNote = Note(.C, accidental: .natural, octave: 0)
         let newLetterIndex = (noteClass.letter.rawValue + (shift.degree - 1))
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
-        let newOctave = (Int(pitch.midiNoteNumber) + shift.semitones) / 12 - 1
+        let newOctave = calculateOctave(newLetter: newLetter, carrying: newLetterIndex / Letter.allCases.count)
         for accidental in Accidental.allCases {
             newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) + shift.semitones) % 12) {
@@ -141,6 +143,20 @@ public struct Note: Equatable, Hashable, Codable {
             }
         }
         return nil
+    }
+    
+    /// Calculate new octave
+    /// - Parameters:
+    ///   - newLetter: Shifted letter
+    ///   - carrying: The number carry-up or carry-down
+    /// - Returns: Calculated new octave
+    private func calculateOctave(newLetter: Letter, carrying: Int) -> Int {
+        return (
+            Int(pitch.midiNoteNumber) +
+            Int(newLetter.baseNote) - Int(letter.baseNote)
+        ) / 12
+        + carrying
+        - 1
     }
 }
 

--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -142,7 +142,7 @@ public struct Note: Equatable, Hashable, Codable {
         }
         return nil
     }
-    
+
     /// Calculate new octave
     /// - Parameters:
     ///   - newLetter: Shifted letter

--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -108,7 +108,6 @@ public struct Note: Equatable, Hashable, Codable {
     /// - Parameter shift: The interval by which to shift
     /// - Returns: New note the correct distance away
     public func shiftDown(_ shift: Interval) -> Note? {
-        var newNote = Note(.C, accidental: .natural, octave: 0)
         var newLetterIndex = (noteClass.letter.rawValue - (shift.degree - 1))
         var carrying = 0
 
@@ -120,7 +119,7 @@ public struct Note: Equatable, Hashable, Codable {
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
         let newOctave = calculateOctave(newLetter: newLetter, carrying: carrying)
         for accidental in Accidental.allCases {
-            newNote = Note(newLetter, accidental: accidental, octave: newOctave)
+            let newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) - shift.semitones) % 12) {
                 return newNote
             }
@@ -132,12 +131,11 @@ public struct Note: Equatable, Hashable, Codable {
     /// - Parameter shift: The interval by which to shift
     /// - Returns: New note the correct distance away
     public func shiftUp(_ shift: Interval) -> Note? {
-        var newNote = Note(.C, accidental: .natural, octave: 0)
         let newLetterIndex = (noteClass.letter.rawValue + (shift.degree - 1))
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
         let newOctave = calculateOctave(newLetter: newLetter, carrying: newLetterIndex / Letter.allCases.count)
         for accidental in Accidental.allCases {
-            newNote = Note(newLetter, accidental: accidental, octave: newOctave)
+            let newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) + shift.semitones) % 12) {
                 return newNote
             }

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -89,6 +89,15 @@ final class NoteTests: XCTestCase {
 
         let g = Note(.C, octave: 6).shiftDown(.P11)
         XCTAssertEqual(g!.description, "G4")
+        
+        var notesAugmentedTriadShiftUpIntoE: [Note] = []
+        for interval in ChordType.augmentedTriad.intervals {
+            if let shifted = Note(.E, accidental: .natural, octave: 0).shiftUp(interval) {
+                notesAugmentedTriadShiftUpIntoE.append(shifted)
+            }
+        }
+        XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[0].description, "G♯0")
+        XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[1].description, "B♯0")
     }
 
     func testNoteShiftLimits() {

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -89,7 +89,7 @@ final class NoteTests: XCTestCase {
 
         let g = Note(.C, octave: 6).shiftDown(.P11)
         XCTAssertEqual(g!.description, "G4")
-        
+
         var notesAugmentedTriadShiftUpIntoE: [Note] = []
         for interval in ChordType.augmentedTriad.intervals {
             if let shifted = Note(.E, accidental: .natural, octave: 0).shiftUp(interval) {


### PR DESCRIPTION
#26 
I took care of this issue.  
Perhaps variable name "carrying" should be changed.
I don't know much about music-theory, so I can't give it a proper name.