### PR TITLE
Fix bug shift up

### DIFF
--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -108,7 +108,6 @@ public struct Note: Equatable, Hashable, Codable {
     /// - Parameter shift: The interval by which to shift
     /// - Returns: New note the correct distance away
     public func shiftDown(_ shift: Interval) -> Note? {
-        var newNote = Note(.C, accidental: .natural, octave: 0)
         var newLetterIndex = (noteClass.letter.rawValue - (shift.degree - 1))
         let newOctave = (Int(pitch.midiNoteNumber) - shift.semitones) / 12 - 1
 
@@ -118,7 +117,7 @@ public struct Note: Equatable, Hashable, Codable {
 
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
         for accidental in Accidental.allCases {
-            newNote = Note(newLetter, accidental: accidental, octave: newOctave)
+            let newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) - shift.semitones) % 12) {
                 return newNote
             }
@@ -130,12 +129,11 @@ public struct Note: Equatable, Hashable, Codable {
     /// - Parameter shift: The interval by which to shift
     /// - Returns: New note the correct distance away
     public func shiftUp(_ shift: Interval) -> Note? {
-        var newNote = Note(.C, accidental: .natural, octave: 0)
         let newLetterIndex = (noteClass.letter.rawValue + (shift.degree - 1))
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
         let newOctave = (Int(pitch.midiNoteNumber) + shift.semitones) / 12 - 1
         for accidental in Accidental.allCases {
-            newNote = Note(newLetter, accidental: accidental, octave: newOctave)
+            let newNote = Note(newLetter, accidental: accidental, octave: newOctave)
             if (newNote.noteNumber % 12) == ((Int(noteNumber) + shift.semitones) % 12) {
                 return newNote
             }

--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -131,10 +131,14 @@ public struct Note: Equatable, Hashable, Codable {
     public func shiftUp(_ shift: Interval) -> Note? {
         let newLetterIndex = (noteClass.letter.rawValue + (shift.degree - 1))
         let newLetter = Letter(rawValue: newLetterIndex % Letter.allCases.count)!
-        let newOctave = (Int(pitch.midiNoteNumber) + shift.semitones) / 12 - 1
+        let newMidiNoteNumber = Int(pitch.midiNoteNumber) + shift.semitones
+        let newOctave =
+        newMidiNoteNumber / 12
+        - ((newMidiNoteNumber % 12 == 0 && newLetter == .B) ? 1 : 0)
+        - 1
         for accidental in Accidental.allCases {
             let newNote = Note(newLetter, accidental: accidental, octave: newOctave)
-            if (newNote.noteNumber % 12) == ((Int(noteNumber) + shift.semitones) % 12) {
+            if newNote.noteNumber == newMidiNoteNumber {
                 return newNote
             }
         }

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -91,6 +91,20 @@ final class NoteTests: XCTestCase {
         XCTAssertEqual(g!.description, "G4")
     }
 
+    func testNoteShiftBSharp() {
+        let bsharp0 = Note(.G, accidental: .sharp, octave: 0).shiftUp(.M3)
+        XCTAssertEqual(bsharp0!.description, "B♯0")
+
+        var notesAugmentedTriadShiftUpIntoE: [Note] = []
+        for interval in ChordType.augmentedTriad.intervals {
+            if let shifted = Note(.E, accidental: .natural, octave: 0).shiftUp(interval) {
+                notesAugmentedTriadShiftUpIntoE.append(shifted)
+            }
+        }
+        XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[0].description, "G♯0")
+        XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[1].description, "B♯0")
+    }
+
     func testNoteShiftLimits() {
         let ebbb = Note(.F, accidental: .doubleFlat).shiftDown(.M2)
         XCTAssertNil(ebbb)

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -92,6 +92,12 @@ final class NoteTests: XCTestCase {
     }
 
     func testNoteShiftBSharp() {
+        let c1 = Note(.C, accidental: .natural, octave: 1).shiftUp(.P1)
+        XCTAssertEqual(c1!.description, "C1")
+
+        let c1_2 = Note(.A, accidental: .flat, octave: 0).shiftUp(.M3)
+        XCTAssertEqual(c1_2!.description, "C1")
+
         let bsharp0 = Note(.G, accidental: .sharp, octave: 0).shiftUp(.M3)
         XCTAssertEqual(bsharp0!.description, "B♯0")
 
@@ -103,6 +109,15 @@ final class NoteTests: XCTestCase {
         }
         XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[0].description, "G♯0")
         XCTAssertEqual(notesAugmentedTriadShiftUpIntoE[1].description, "B♯0")
+
+        var notesMinorTriadShiftUpIntoA: [Note] = []
+        for interval in ChordType.minorTriad.intervals {
+            if let shifted = Note(.A, accidental: .natural, octave: 0).shiftUp(interval) {
+                notesMinorTriadShiftUpIntoA.append(shifted)
+            }
+        }
+        XCTAssertEqual(notesMinorTriadShiftUpIntoA[0].description, "C1")
+        XCTAssertEqual(notesMinorTriadShiftUpIntoA[1].description, "E1")
     }
 
     func testNoteShiftLimits() {


### PR DESCRIPTION
#26 
I took care of this issue.

Following aure's suggestion, I first write some tests.
As a result, #35 has some problems. I'm sorry.

I have considered several possibilities, but it seems to me that the condition "newLetter is B" or "newLetter is not C" is necessary.
So I think the handling written in #26 is fine, but this one has less time complexity.