### PR TITLE
Added minorSeventhSharpFive

### DIFF
--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -200,7 +200,7 @@ extension Chord {
             returnArray.append(contentsOf: Chord.getRankedChords(from: noteArray))
         }
         
-        // Sorts anti-alphabetical, but the net effect is to pefer flats to sharps
+        // Sorts anti-alphabetical, but the net effect is to prefer flats to sharps
         returnArray.sort { $0.root.letter > $1.root.letter }
 
         // order the array by least number of accidentals

--- a/Sources/Tonic/ChordType.swift
+++ b/Sources/Tonic/ChordType.swift
@@ -110,11 +110,14 @@ public enum ChordType: String, CaseIterable, Codable {
     /// Half Diminished Ninth: Minor Third, Diminished Fifth, Minor Seventh, Minor Ninth, Perfect Eleventh
     case halfDiminishedEleventh
 
-    /// Minor Seventh Flat Five: Major Third, Diminished Fifth, Major Seventh
+    /// Major Seventh Flat Five: Major Third, Diminished Fifth, Major Seventh
     case majorSeventhFlatFive
 
     /// Major Seventh Sharp Five: Major Third, Augmented Fifth, Major Seventh
     case majorSeventhSharpFive
+    
+    /// Minor Seventh Flat Five: Minor Third, Diminished Fifth, Major Seventh
+    case minorSeventhSharpFive
     
     /// Minor Ninth Flat Five: Major Third, Diminished Fifth, Major Seventh, Major Nine
     case majorNinthFlatFive
@@ -208,6 +211,7 @@ public enum ChordType: String, CaseIterable, Codable {
             case .halfDiminishedEleventh:           return [.m3, .d5, .m7, .m9, .P11]
             case .majorSeventhFlatFive:             return [.M3, .d5, .M7]
             case .majorSeventhSharpFive:            return [.M3, .A5, .M7]
+            case .minorSeventhSharpFive:            return [.m3, .A5, .m7]
             case .majorNinthSharpEleventh:          return [.M3, .P5, .M7, .M9, .A11]
             case .dominantFlatNinthSharpEleventh:   return [.M3, .P5, .m7, .m9, .A11]
             case .dominantFlatFive:                 return [.M3, .d5, .m7]
@@ -270,6 +274,7 @@ extension ChordType: CustomStringConvertible {
             case .minorEleventh:                    return "m11"
             case .halfDiminishedEleventh:           return "ø11"
             case .majorSeventhFlatFive:             return "maj7♭5"
+            case .minorSeventhSharpFive:            return "m7♯5"
             case .majorSeventhSharpFive:            return "maj7♯5"
             case .majorNinthSharpEleventh:          return "maj9♯11"
             case .dominantFlatFive:                 return "7♭5"
@@ -333,6 +338,7 @@ extension ChordType: CustomStringConvertible {
             case .halfDiminishedEleventh:           return "Ø11"
             case .majorSeventhFlatFive:             return "^7b5"
             case .majorSeventhSharpFive:            return "^7#5"
+            case .minorSeventhSharpFive:            return "m7#5"
             case .majorNinthSharpEleventh:          return "^9#11"
             case .dominantFlatFive:                 return "7b5"
             case .dominantSharpFive:                return "7#5"

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -55,7 +55,6 @@ class ChordTests: XCTestCase {
     
     func testMinorSeventhSharpFive() {
         let notes: [Int8] = [60, 63, 68, 71]
-        let pitchSet =  PitchSet(pitches: notes.map { Pitch($0) } )
         let chord = Chord(.C, type: .minorSeventhSharpFive)
         XCTAssertEqual(chord.description, "Cm7♯5")
     }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -46,6 +46,20 @@ class ChordTests: XCTestCase {
         XCTAssertEqual(chord.map { $0.description }, ["Cmaj7♭5"])
     }
     
+    func testMajorSeventhSharpFive() {
+        let notes: [Int8] = [60, 64, 68, 71]
+        let pitchSet =  PitchSet(pitches: notes.map { Pitch($0) } )
+        let chord = Chord.getRankedChords(from: pitchSet)
+        XCTAssertEqual(chord.map { $0.description }, ["Cmaj7♯5"])
+    }
+    
+    func testMinorSeventhSharpFive() {
+        let notes: [Int8] = [60, 63, 68, 71]
+        let pitchSet =  PitchSet(pitches: notes.map { Pitch($0) } )
+        let chord = Chord(.C, type: .minorSeventhSharpFive)
+        XCTAssertEqual(chord.description, "Cm7♯5")
+    }
+    
     func testMajorNinthFlatFive() {
         let notes: [Int8] = [60, 64, 66, 71, 74]
         let pitchSet =  PitchSet(pitches: notes.map { Pitch($0) } )


### PR DESCRIPTION
This adds a minorSeventhSharpFive chord. 

There may be something funny going on with Chord.getRankedChords. I tried using that method but it didn't find the new chord. However, using Chord(.C, type: .minorSeventhSharpFive) works in the test.

*Fixed a couple of typos in comments too