### PR TITLE
Removes Codable from definitions

### DIFF
--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// A representation of a chord as a set of note classes, with a root note class,
 /// and an inversion defined by the lowest note in the chord.
-public struct Chord: Equatable, Codable {
+public struct Chord: Equatable {
     /// Root note class of the chord
     public let root: NoteClass
 

--- a/Sources/Tonic/ChordType.swift
+++ b/Sources/Tonic/ChordType.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Chord type as defined by a set of intervals from a root note class
-public enum ChordType: String, CaseIterable, Codable {
+public enum ChordType: String, CaseIterable {
 
     /// Major Triad: Major Third, Perfect Fifth
     case majorTriad

--- a/Sources/Tonic/Key.swift
+++ b/Sources/Tonic/Key.swift
@@ -5,7 +5,7 @@ import Foundation
 /// The key is the set of notes that are played in a composition, or portion of a composition.
 ///
 /// A key is composed of a Root ``Note``, and a ``Scale``.
-public struct Key: Equatable, Codable {
+public struct Key: Equatable {
     /// The primary note class of the key, also known as the tonic
     public let root: NoteClass
 


### PR DESCRIPTION
We should let the consumer of the package add Codable conformances if they need it. Tonic does not depend on these conformances.

The reason being that Swift doesn't allow you to override the default encode/decode behavior if defined in the package. This is inflexible for the consumer of the package.

Example of a problem that I just ran into:
I defined my own coding keys and encode/decode methods for these structs and used them in my save files. I did this because at the time of writing the code our raw values were integers and I wanted keys which would not change with future updates to the package. However, now that we added Codable to the package I am forced to use the package's raw values for coding keys and the default encode/decode. This breaks my save files in a way that would require a significant refactor to resolve.

TLDR - let the developer using the package add this in their codebase:
extension ChordType: Codable {}