### PR TITLE
test: romanNumeralNotation throws on index out of range

### DIFF
--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -195,7 +195,6 @@ class ChordTests: XCTestCase {
                        ["i", "ii°", "III", "iv", "v", "VI", "VII"])
         XCTAssertEqual(Key.Am.primaryTriads.map { $0.romanNumeralNotation(in: Key.C) ?? "" },
                        ["vi", "vii°", "I", "ii", "iii", "IV", "V"])
-        
         let key = Key(root: .C, scale: .wholeDiminished)
         XCTAssertNoThrow(key.primaryTriads.map { $0.romanNumeralNotation(in: key) ?? "" })
     }

--- a/Tests/TonicTests/ChordTests.swift
+++ b/Tests/TonicTests/ChordTests.swift
@@ -195,6 +195,9 @@ class ChordTests: XCTestCase {
                        ["i", "ii°", "III", "iv", "v", "VI", "VII"])
         XCTAssertEqual(Key.Am.primaryTriads.map { $0.romanNumeralNotation(in: Key.C) ?? "" },
                        ["vi", "vii°", "I", "ii", "iii", "IV", "V"])
+        
+        let key = Key(root: .C, scale: .wholeDiminished)
+        XCTAssertNoThrow(key.primaryTriads.map { $0.romanNumeralNotation(in: key) ?? "" })
     }
 
     func testTriadNaming() {


### PR DESCRIPTION
Hi, I found this but I am not sure if it's a bug or not. 

When generating roman romanNumeralNotation for non diatonic scales, for example the `wholeDiminished` one, the function crashes due to index out of range. 

I am doing something like this: 
```swift
let key = Key(root: .C, scale: .wholeDiminished)
let romanNumerals  = key.primaryTriads.map { $0.romanNumeralNotation(in: key) ?? "" 
```

Maybe this is expected behavior, since for some scales it may not make much sense to generate Roman numeral notation. However, I would expect the function to either return an empty string or declare throws in its signature,  so that callers can remain agnostic of the scale used to generate the key, without needing to handle special cases manually.

This would be enough to avoid the out of range issue:
```swift
    public func romanNumeralNotation(in key: Key) -> String? {
        let capitalRomanNumerals = ["I", "II", "III", "IV", "V", "VI", "VII"]
        
        if let index = key.primaryTriads.firstIndex(where: { $0 == self }),
           index < capitalRomanNumerals.count {
            
            let romanNumeral = capitalRomanNumerals[index]
            
            switch type {
            case .major: return romanNumeral
            case .minor: return romanNumeral.lowercased()
            case .dim: return "\(romanNumeral.lowercased())°"
            default: return nil
            }
        }
        return nil
    }
```