### PR TITLE
Added more sweeping conformances to `Sendable` and `Hashable`; made "shortcuts" concurrency-safe

### DIFF
--- a/Sources/Tonic/Accidental.swift
+++ b/Sources/Tonic/Accidental.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A way to describe modification to a ``Note`` or ``NoteClass``
 ///
 /// A semitone offset applied to a note that does not change the letter of the note, just the pitch.
-public enum Accidental: Int8, CaseIterable, Equatable, Hashable, Codable {
+public enum Accidental: Int8, Sendable, CaseIterable, Equatable, Hashable, Codable {
     static var count: Int { Accidental.allCases.count }
     static var naturalIndex: Int { count / 2 }
 

--- a/Sources/Tonic/BitSet.swift
+++ b/Sources/Tonic/BitSet.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Interface to bit sets used to represent sets of pitches and sets of notes.
-public protocol BitSet: Hashable, Codable {
+public protocol BitSet: Hashable, Codable, Sendable {
     init()
     func isSet(bit: Int) -> Bool
     mutating func add(bit: Int)

--- a/Sources/Tonic/BitSet.swift
+++ b/Sources/Tonic/BitSet.swift
@@ -195,7 +195,7 @@ public protocol IntRepresentable {
     var intValue: Int { get }
 }
 
-public struct BitSetAdapter<T: IntRepresentable, B: BitSet>: Hashable, Codable {
+public struct BitSetAdapter<T: IntRepresentable, B: BitSet>: Sendable, Hashable, Codable {
     public var bits: B
 
     public init() {

--- a/Sources/Tonic/Chord+Shortcuts.swift
+++ b/Sources/Tonic/Chord+Shortcuts.swift
@@ -6,362 +6,362 @@ public extension Chord {
     // MARK: - Natural Major chords
 
     /// C Major
-    static var C = Chord(.C, type: .major)
+    static let C = Chord(.C, type: .major)
 
     /// D Major
-    static var D = Chord(.D, type: .major)
+    static let D = Chord(.D, type: .major)
 
     /// E Major
-    static var E = Chord(.E, type: .major)
+    static let E = Chord(.E, type: .major)
 
     /// F Major
-    static var F = Chord(.F, type: .major)
+    static let F = Chord(.F, type: .major)
 
     /// G Major
-    static var G = Chord(.G, type: .major)
+    static let G = Chord(.G, type: .major)
 
     /// A Major
-    static var A = Chord(.A, type: .major)
+    static let A = Chord(.A, type: .major)
 
     /// B Major
-    static var B = Chord(.B, type: .major)
+    static let B = Chord(.B, type: .major)
 
     // MARK: - Natural Minor chords
 
     /// C Minor
-    static var Cm = Chord(.C, type: .minor)
+    static let Cm = Chord(.C, type: .minor)
 
     /// D Minor
-    static var Dm = Chord(.D, type: .minor)
+    static let Dm = Chord(.D, type: .minor)
 
     /// E Minor
-    static var Em = Chord(.E, type: .minor)
+    static let Em = Chord(.E, type: .minor)
 
     /// F Minor
-    static var Fm = Chord(.F, type: .minor)
+    static let Fm = Chord(.F, type: .minor)
 
     /// G Minor
-    static var Gm = Chord(.G, type: .minor)
+    static let Gm = Chord(.G, type: .minor)
 
     /// A Minor
-    static var Am = Chord(.A, type: .minor)
+    static let Am = Chord(.A, type: .minor)
 
     /// B Minor
-    static var Bm = Chord(.B, type: .minor)
+    static let Bm = Chord(.B, type: .minor)
 
     // MARK: - Natural Diminished chords
 
     /// C Diminished - C°
-    static var Cdim = Chord(.C, type: .dim)
+    static let Cdim = Chord(.C, type: .dim)
 
     /// D Diminished - D°
-    static var Ddim = Chord(.D, type: .dim)
+    static let Ddim = Chord(.D, type: .dim)
 
     /// E Diminished - E°
-    static var Edim = Chord(.E, type: .dim)
+    static let Edim = Chord(.E, type: .dim)
 
     /// F Diminished - F°
-    static var Fdim = Chord(.F, type: .dim)
+    static let Fdim = Chord(.F, type: .dim)
 
     /// G Diminished - G°
-    static var Gdim = Chord(.G, type: .dim)
+    static let Gdim = Chord(.G, type: .dim)
 
     /// A Diminished - A°
-    static var Adim = Chord(.A, type: .dim)
+    static let Adim = Chord(.A, type: .dim)
 
     /// B Diminished - B°
-    static var Bdim = Chord(.B, type: .dim)
+    static let Bdim = Chord(.B, type: .dim)
 
     // MARK: - Natural Augmented chords
 
     /// C Augmented - C⁺
-    static var Caug = Chord(.C, type: .aug)
+    static let Caug = Chord(.C, type: .aug)
 
     /// D Augmented - D⁺
-    static var Daug = Chord(.D, type: .aug)
+    static let Daug = Chord(.D, type: .aug)
 
     /// E Augmented - E⁺
-    static var Eaug = Chord(.E, type: .aug)
+    static let Eaug = Chord(.E, type: .aug)
 
     /// F Augmented - F⁺
-    static var Faug = Chord(.F, type: .aug)
+    static let Faug = Chord(.F, type: .aug)
 
     /// G Augmented - G⁺
-    static var Gaug = Chord(.G, type: .aug)
+    static let Gaug = Chord(.G, type: .aug)
 
     /// A Augmented - A⁺
-    static var Aaug = Chord(.A, type: .aug)
+    static let Aaug = Chord(.A, type: .aug)
 
     /// B Augmented - B⁺
-    static var Baug = Chord(.B, type: .aug)
+    static let Baug = Chord(.B, type: .aug)
 
     // MARK: - Natural Suspended chords
 
     /// C Suspended Fourth - Csus4
-    static var Csus4 = Chord(.C, type: .sus4)
+    static let Csus4 = Chord(.C, type: .sus4)
 
     /// D Suspended Fourth - Dsus4
-    static var Dsus4 = Chord(.D, type: .sus4)
+    static let Dsus4 = Chord(.D, type: .sus4)
 
     /// E Suspended Fourth - Esus4
-    static var Esus4 = Chord(.E, type: .sus4)
+    static let Esus4 = Chord(.E, type: .sus4)
 
     /// F Suspended Fourth - Fsus4
-    static var Fsus4 = Chord(.F, type: .sus4)
+    static let Fsus4 = Chord(.F, type: .sus4)
 
     /// G Suspended Fourth - Gsus4
-    static var Gsus4 = Chord(.G, type: .sus4)
+    static let Gsus4 = Chord(.G, type: .sus4)
 
     /// A Suspended Fourth - Asus4
-    static var Asus4 = Chord(.A, type: .sus4)
+    static let Asus4 = Chord(.A, type: .sus4)
 
     /// B Suspended Fourth - Bsus4
-    static var Bsus4 = Chord(.B, type: .sus4)
+    static let Bsus4 = Chord(.B, type: .sus4)
 
     /// C Suspended Second - Csus2
-    static var Csus2 = Chord(.C, type: .sus2)
+    static let Csus2 = Chord(.C, type: .sus2)
 
     /// D Suspended Second - Dsus2
-    static var Dsus2 = Chord(.D, type: .sus2)
+    static let Dsus2 = Chord(.D, type: .sus2)
 
     /// E Suspended Second - Esus2
-    static var Esus2 = Chord(.E, type: .sus2)
+    static let Esus2 = Chord(.E, type: .sus2)
 
     /// F Suspended Second - Fsus2
-    static var Fsus2 = Chord(.F, type: .sus2)
+    static let Fsus2 = Chord(.F, type: .sus2)
 
     /// G Suspended Second - Gsus2
-    static var Gsus2 = Chord(.G, type: .sus2)
+    static let Gsus2 = Chord(.G, type: .sus2)
 
     /// A Suspended Second - Asus2
-    static var Asus2 = Chord(.A, type: .sus2)
+    static let Asus2 = Chord(.A, type: .sus2)
 
     /// B Suspended Second - Bsus2
-    static var Bsus2 = Chord(.B, type: .sus2)
+    static let Bsus2 = Chord(.B, type: .sus2)
 
     // MARK: - Sharp Major chords
 
     /// C♯ Major
-    static var Cs = Chord(.Cs, type: .major)
+    static let Cs = Chord(.Cs, type: .major)
 
     /// D♯ Major
-    static var Ds = Chord(.Ds, type: .major)
+    static let Ds = Chord(.Ds, type: .major)
 
     /// E♯ Major
-    static var Es = Chord(.Es, type: .major)
+    static let Es = Chord(.Es, type: .major)
 
     /// F♯ Major
-    static var Fs = Chord(.Fs, type: .major)
+    static let Fs = Chord(.Fs, type: .major)
 
     /// G♯ Major
-    static var Gs = Chord(.Gs, type: .major)
+    static let Gs = Chord(.Gs, type: .major)
 
     /// A♯ Major
-    static var As = Chord(.As, type: .major)
+    static let As = Chord(.As, type: .major)
 
     /// B♯ Major
-    static var Bs = Chord(.Bs, type: .major)
+    static let Bs = Chord(.Bs, type: .major)
 
     // MARK: - Sharp Minor chords
 
     /// C♯ Minor
-    static var Csm = Chord(.Cs, type: .minor)
+    static let Csm = Chord(.Cs, type: .minor)
 
     /// D♯ Minor
-    static var Dsm = Chord(.Ds, type: .minor)
+    static let Dsm = Chord(.Ds, type: .minor)
 
     /// E♯ Minor
-    static var Esm = Chord(.Es, type: .minor)
+    static let Esm = Chord(.Es, type: .minor)
 
     /// F♯ Minor
-    static var Fsm = Chord(.Fs, type: .minor)
+    static let Fsm = Chord(.Fs, type: .minor)
 
     /// G♯ Minor
-    static var Gsm = Chord(.Gs, type: .minor)
+    static let Gsm = Chord(.Gs, type: .minor)
 
     /// A♯ Minor
-    static var Asm = Chord(.As, type: .minor)
+    static let Asm = Chord(.As, type: .minor)
 
     /// B♯ Minor
-    static var Bsm = Chord(.Bs, type: .minor)
+    static let Bsm = Chord(.Bs, type: .minor)
 
     // MARK: - Sharp Diminished chords
 
     /// C♯ Diminished - C♯°
-    static var Csdim = Chord(.Cs, type: .dim)
+    static let Csdim = Chord(.Cs, type: .dim)
 
     /// D♯ Diminished - D♯°
-    static var Dsdim = Chord(.Ds, type: .dim)
+    static let Dsdim = Chord(.Ds, type: .dim)
 
     /// E♯ Diminished - E♯°
-    static var Esdim = Chord(.Es, type: .dim)
+    static let Esdim = Chord(.Es, type: .dim)
 
     /// F♯ Diminished - F♯°
-    static var Fsdim = Chord(.Fs, type: .dim)
+    static let Fsdim = Chord(.Fs, type: .dim)
 
     /// G♯ Diminished - G♯°
-    static var Gsdim = Chord(.Gs, type: .dim)
+    static let Gsdim = Chord(.Gs, type: .dim)
 
     /// A♯ Diminished - A♯°
-    static var Asdim = Chord(.As, type: .dim)
+    static let Asdim = Chord(.As, type: .dim)
 
     /// B♯ Diminished - B♯°
-    static var Bsdim = Chord(.Bs, type: .dim)
+    static let Bsdim = Chord(.Bs, type: .dim)
 
     // MARK: - Sharp Suspended chords
 
     /// C♯ Suspended Fourth - C♯sus4
-    static var Cssus4 = Chord(.Cs, type: .sus4)
+    static let Cssus4 = Chord(.Cs, type: .sus4)
 
     /// D♯ Suspended Fourth - D♯sus4
-    static var Dssus4 = Chord(.Ds, type: .sus4)
+    static let Dssus4 = Chord(.Ds, type: .sus4)
 
     /// E♯ Suspended Fourth - E♯sus4
-    static var Essus4 = Chord(.Es, type: .sus4)
+    static let Essus4 = Chord(.Es, type: .sus4)
 
     /// F♯ Suspended Fourth - F♯sus4
-    static var Fssus4 = Chord(.Fs, type: .sus4)
+    static let Fssus4 = Chord(.Fs, type: .sus4)
 
     /// G♯ Suspended Fourth - G♯sus4
-    static var Gssus4 = Chord(.Gs, type: .sus4)
+    static let Gssus4 = Chord(.Gs, type: .sus4)
 
     /// A♯ Suspended Fourth - A♯sus4
-    static var Assus4 = Chord(.As, type: .sus4)
+    static let Assus4 = Chord(.As, type: .sus4)
 
     /// B♯ Suspended Fourth - B♯sus4
-    static var Bssus4 = Chord(.Bs, type: .sus4)
+    static let Bssus4 = Chord(.Bs, type: .sus4)
 
     /// C♯ Suspended Second - C♯sus2
-    static var Cssus2 = Chord(.Cs, type: .sus2)
+    static let Cssus2 = Chord(.Cs, type: .sus2)
 
     /// D♯ Suspended Second - D♯sus2
-    static var Dssus2 = Chord(.Ds, type: .sus2)
+    static let Dssus2 = Chord(.Ds, type: .sus2)
 
     /// E♯ Suspended Second - E♯sus2
-    static var Essus2 = Chord(.Es, type: .sus2)
+    static let Essus2 = Chord(.Es, type: .sus2)
 
     /// F♯ Suspended Second - F♯sus2
-    static var Fssus2 = Chord(.Fs, type: .sus2)
+    static let Fssus2 = Chord(.Fs, type: .sus2)
 
     /// G♯ Suspended Second - G♯sus2
-    static var Gssus2 = Chord(.Gs, type: .sus2)
+    static let Gssus2 = Chord(.Gs, type: .sus2)
 
     /// A♯ Suspended Second - A♯sus2
-    static var Assus2 = Chord(.As, type: .sus2)
+    static let Assus2 = Chord(.As, type: .sus2)
 
     /// B♯ Suspended Second - B♯sus2
-    static var Bssus2 = Chord(.Bs, type: .sus2)
+    static let Bssus2 = Chord(.Bs, type: .sus2)
 
     // MARK: - Flat Major chords
 
     /// C♭ Major
-    static var Cb = Chord(.Cb, type: .major)
+    static let Cb = Chord(.Cb, type: .major)
 
     /// D♭ Major
-    static var Db = Chord(.Db, type: .major)
+    static let Db = Chord(.Db, type: .major)
 
     /// E♭ Major
-    static var Eb = Chord(.Eb, type: .major)
+    static let Eb = Chord(.Eb, type: .major)
 
     /// F♭ Major
-    static var Fb = Chord(.Fb, type: .major)
+    static let Fb = Chord(.Fb, type: .major)
 
     /// G♭ Major
-    static var Gb = Chord(.Gb, type: .major)
+    static let Gb = Chord(.Gb, type: .major)
 
     /// A♭ Major
-    static var Ab = Chord(.Ab, type: .major)
+    static let Ab = Chord(.Ab, type: .major)
 
     /// B♭ Major
-    static var Bb = Chord(.Bb, type: .major)
+    static let Bb = Chord(.Bb, type: .major)
 
     // MARK: - Flat Minor chords
 
     /// C♭ Minor
-    static var Cbm = Chord(.Cb, type: .minor)
+    static let Cbm = Chord(.Cb, type: .minor)
 
     /// D♭ Minor
-    static var Dbm = Chord(.Db, type: .minor)
+    static let Dbm = Chord(.Db, type: .minor)
 
     /// E♭ Minor
-    static var Ebm = Chord(.Eb, type: .minor)
+    static let Ebm = Chord(.Eb, type: .minor)
 
     /// F♭ Minor
-    static var Fbm = Chord(.Fb, type: .minor)
+    static let Fbm = Chord(.Fb, type: .minor)
 
     /// G♭ Minor
-    static var Gbm = Chord(.Gb, type: .minor)
+    static let Gbm = Chord(.Gb, type: .minor)
 
     /// A♭ Minor
-    static var Abm = Chord(.Ab, type: .minor)
+    static let Abm = Chord(.Ab, type: .minor)
 
     /// B♭ Minor
-    static var Bbm = Chord(.Bb, type: .minor)
+    static let Bbm = Chord(.Bb, type: .minor)
 
     // MARK: - Flat Diminished chords
 
     /// C♭ Diminished - C♭°
-    static var Cbdim = Chord(.Cb, type: .dim)
+    static let Cbdim = Chord(.Cb, type: .dim)
 
     /// D♭ Diminished - D♭°
-    static var Dbdim = Chord(.Db, type: .dim)
+    static let Dbdim = Chord(.Db, type: .dim)
 
     /// E♭ Diminished - E♭°
-    static var Ebdim = Chord(.Eb, type: .dim)
+    static let Ebdim = Chord(.Eb, type: .dim)
 
     /// F♭ Diminished - F♭°
-    static var Fbdim = Chord(.Fb, type: .dim)
+    static let Fbdim = Chord(.Fb, type: .dim)
 
     /// G♭ Diminished - G♭°
-    static var Gbdim = Chord(.Gb, type: .dim)
+    static let Gbdim = Chord(.Gb, type: .dim)
 
     /// A♭ Diminished - A♭°
-    static var Abdim = Chord(.Ab, type: .dim)
+    static let Abdim = Chord(.Ab, type: .dim)
 
     /// B♭ Diminished - B♭°
-    static var Bbdim = Chord(.Bb, type: .dim)
+    static let Bbdim = Chord(.Bb, type: .dim)
 
     // MARK: - Flat Suspended chords
 
     /// C♭ Suspended Fourth - C♭sus4
-    static var Cbsus4 = Chord(.Cb, type: .sus4)
+    static let Cbsus4 = Chord(.Cb, type: .sus4)
 
     /// D♭ Suspended Fourth - D♭sus4
-    static var Dbsus4 = Chord(.Db, type: .sus4)
+    static let Dbsus4 = Chord(.Db, type: .sus4)
 
     /// E♭ Suspended Fourth - E♭sus4
-    static var Ebsus4 = Chord(.Eb, type: .sus4)
+    static let Ebsus4 = Chord(.Eb, type: .sus4)
 
     /// F♭ Suspended Fourth - F♭sus4
-    static var Fbsus4 = Chord(.Fb, type: .sus4)
+    static let Fbsus4 = Chord(.Fb, type: .sus4)
 
     /// G♭ Suspended Fourth - G♭sus4
-    static var Gbsus4 = Chord(.Gb, type: .sus4)
+    static let Gbsus4 = Chord(.Gb, type: .sus4)
 
     /// A♭ Suspended Fourth - A♭sus4
-    static var Absus4 = Chord(.Ab, type: .sus4)
+    static let Absus4 = Chord(.Ab, type: .sus4)
 
     /// B♭ Suspended Fourth - B♭sus4
-    static var Bbsus4 = Chord(.Bb, type: .sus4)
+    static let Bbsus4 = Chord(.Bb, type: .sus4)
 
     /// C♭ Suspended Fourth - C♭sus2
-    static var Cbsus2 = Chord(.Cb, type: .sus2)
+    static let Cbsus2 = Chord(.Cb, type: .sus2)
 
     /// D♭ Suspended Fourth - D♭sus2
-    static var Dbsus2 = Chord(.Db, type: .sus2)
+    static let Dbsus2 = Chord(.Db, type: .sus2)
 
     /// E♭ Suspended Fourth - E♭sus2
-    static var Ebsus2 = Chord(.Eb, type: .sus2)
+    static let Ebsus2 = Chord(.Eb, type: .sus2)
 
     /// F♭ Suspended Fourth - F♭sus2
-    static var Fbsus2 = Chord(.Fb, type: .sus2)
+    static let Fbsus2 = Chord(.Fb, type: .sus2)
 
     /// G♭ Suspended Fourth - G♭sus2
-    static var Gbsus2 = Chord(.Gb, type: .sus2)
+    static let Gbsus2 = Chord(.Gb, type: .sus2)
 
     /// A♭ Suspended Fourth - A♭sus2
-    static var Absus2 = Chord(.Ab, type: .sus2)
+    static let Absus2 = Chord(.Ab, type: .sus2)
 
     /// B♭ Suspended Fourth - B♭sus2
-    static var Bbsus2 = Chord(.Bb, type: .sus2)
+    static let Bbsus2 = Chord(.Bb, type: .sus2)
 }

--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// A representation of a chord as a set of note classes, with a root note class,
 /// and an inversion defined by the lowest note in the chord.
-public struct Chord: Equatable, Hashable, Codable {
+public struct Chord: Sendable, Equatable, Hashable, Codable {
     /// Root note class of the chord
     public let root: NoteClass
 

--- a/Sources/Tonic/Chord.swift
+++ b/Sources/Tonic/Chord.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// A representation of a chord as a set of note classes, with a root note class,
 /// and an inversion defined by the lowest note in the chord.
-public struct Chord: Equatable, Codable {
+public struct Chord: Equatable, Hashable, Codable {
     /// Root note class of the chord
     public let root: NoteClass
 

--- a/Sources/Tonic/ChordType.swift
+++ b/Sources/Tonic/ChordType.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Chord type as defined by a set of intervals from a root note class
 /// We use abreviated descriptions with extensions seperated by underscores
 /// We don't like usiing underscores for enum cases any more than you do, however is a nice visual speration of extensions
-public enum ChordType: String, CaseIterable, Codable {
+public enum ChordType: String, Sendable, CaseIterable, Codable {
 
 	//MARK: - Triads
     /// Major Triad: Major Third, Perfect Fifth, e.g. `C`

--- a/Sources/Tonic/Interval.swift
+++ b/Sources/Tonic/Interval.swift
@@ -7,7 +7,7 @@ import Foundation
 /// An interval distance is measured in degree (number of letters away) and
 /// quality of the interval (essentially number of semitones away).
 /// Some Intervals refer to the same difference in pitch.
-public enum Interval: Int, CaseIterable, Codable {
+public enum Interval: Int, Sendable, CaseIterable, Codable {
     /// Perfect Unison
     case P1
 

--- a/Sources/Tonic/Key.swift
+++ b/Sources/Tonic/Key.swift
@@ -5,7 +5,7 @@ import Foundation
 /// The key is the set of notes that are played in a composition, or portion of a composition.
 ///
 /// A key is composed of a Root ``Note``, and a ``Scale``.
-public struct Key: Equatable {
+public struct Key: Equatable, Hashable {
     /// The primary note class of the key, also known as the tonic
     public let root: NoteClass
 

--- a/Sources/Tonic/Key.swift
+++ b/Sources/Tonic/Key.swift
@@ -5,7 +5,7 @@ import Foundation
 /// The key is the set of notes that are played in a composition, or portion of a composition.
 ///
 /// A key is composed of a Root ``Note``, and a ``Scale``.
-public struct Key: Equatable, Hashable {
+public struct Key: Sendable, Equatable, Hashable {
     /// The primary note class of the key, also known as the tonic
     public let root: NoteClass
 

--- a/Sources/Tonic/Letter.swift
+++ b/Sources/Tonic/Letter.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// These letters can be modified by adding an ``Accidental`` to describe any ``NoteClass``.
 /// And by specificying an octave, you can create any ``Note``.
-public enum Letter: Int, CaseIterable, Equatable, Hashable, Codable {
+public enum Letter: Int, Sendable, CaseIterable, Equatable, Hashable, Codable {
     case C, D, E, F, G, A, B
 
     var baseNote: UInt8 {

--- a/Sources/Tonic/Note+MiddleCStandard.swift
+++ b/Sources/Tonic/Note+MiddleCStandard.swift
@@ -5,7 +5,7 @@ import Foundation
 
 extension Note {
     /// MIDI note naming style (octave offset).
-    public enum MiddleCStandard: Equatable, Hashable, CaseIterable, Codable {
+    public enum MiddleCStandard: Sendable, Equatable, Hashable, CaseIterable, Codable {
         /// Yamaha (Middle C == C3)
         ///
         /// Yamaha traditionally chose "C3" to represent MIDI note 60 (Middle C).

--- a/Sources/Tonic/Note+Shortcuts.swift
+++ b/Sources/Tonic/Note+Shortcuts.swift
@@ -4,51 +4,51 @@ import Foundation
 
 public extension Note {
     /// C♭
-    static var Cb = Note(.C, accidental: .flat)
+    static let Cb = Note(.C, accidental: .flat)
     /// C
-    static var C = Note(.C)
+    static let C = Note(.C)
     /// C♯
-    static var Cs = Note(.C, accidental: .sharp)
+    static let Cs = Note(.C, accidental: .sharp)
 
     /// D♭
-    static var Db = Note(.D, accidental: .flat)
+    static let Db = Note(.D, accidental: .flat)
     /// D
-    static var D = Note(.D)
+    static let D = Note(.D)
     /// D♯
-    static var Ds = Note(.D, accidental: .sharp)
+    static let Ds = Note(.D, accidental: .sharp)
 
     /// E♭
-    static var Eb = Note(.E, accidental: .flat)
+    static let Eb = Note(.E, accidental: .flat)
     /// E
-    static var E = Note(.E)
+    static let E = Note(.E)
     /// E♯
-    static var Es = Note(.E, accidental: .sharp)
+    static let Es = Note(.E, accidental: .sharp)
 
     /// F♭
-    static var Fb = Note(.F, accidental: .flat)
+    static let Fb = Note(.F, accidental: .flat)
     /// F
-    static var F = Note(.F)
+    static let F = Note(.F)
     /// F♯
-    static var Fs = Note(.F, accidental: .sharp)
+    static let Fs = Note(.F, accidental: .sharp)
 
     /// G♭
-    static var Gb = Note(.G, accidental: .flat)
+    static let Gb = Note(.G, accidental: .flat)
     /// G
-    static var G = Note(.G)
+    static let G = Note(.G)
     /// G♯
-    static var Gs = Note(.G, accidental: .sharp)
+    static let Gs = Note(.G, accidental: .sharp)
 
     /// A♭
-    static var Ab = Note(.A, accidental: .flat)
+    static let Ab = Note(.A, accidental: .flat)
     /// A
-    static var A = Note(.A)
+    static let A = Note(.A)
     /// A♯
-    static var As = Note(.A, accidental: .sharp)
+    static let As = Note(.A, accidental: .sharp)
 
     /// B♭
-    static var Bb = Note(.B, accidental: .flat)
+    static let Bb = Note(.B, accidental: .flat)
     /// B
-    static var B = Note(.B)
+    static let B = Note(.B)
     /// B♯
-    static var Bs = Note(.B, accidental: .sharp)
+    static let Bs = Note(.B, accidental: .sharp)
 }

--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// A pitch with a particular spelling.
-public struct Note: Equatable, Hashable, Codable {
+public struct Note: Sendable, Equatable, Hashable, Codable {
     /// Base name for the note
     public var noteClass: NoteClass = .init(.C, accidental: .natural)
 

--- a/Sources/Tonic/NoteClass+Shortcuts.swift
+++ b/Sources/Tonic/NoteClass+Shortcuts.swift
@@ -6,7 +6,7 @@ public extension NoteClass {
     /// C♭
     static var Cb = NoteClass(.C, accidental: .flat)
     /// C
-    static var C = NoteClass(.C)
+    static let C = NoteClass(.C)
     /// C♯
     static var Cs = NoteClass(.C, accidental: .sharp)
 

--- a/Sources/Tonic/NoteClass+Shortcuts.swift
+++ b/Sources/Tonic/NoteClass+Shortcuts.swift
@@ -4,51 +4,51 @@ import Foundation
 
 public extension NoteClass {
     /// C♭
-    static var Cb = NoteClass(.C, accidental: .flat)
+    static let Cb = NoteClass(.C, accidental: .flat)
     /// C
     static let C = NoteClass(.C)
     /// C♯
-    static var Cs = NoteClass(.C, accidental: .sharp)
+    static let Cs = NoteClass(.C, accidental: .sharp)
 
     /// D♭
-    static var Db = NoteClass(.D, accidental: .flat)
+    static let Db = NoteClass(.D, accidental: .flat)
     /// D
-    static var D = NoteClass(.D)
+    static let D = NoteClass(.D)
     /// D♯
-    static var Ds = NoteClass(.D, accidental: .sharp)
+    static let Ds = NoteClass(.D, accidental: .sharp)
 
     /// E♭
-    static var Eb = NoteClass(.E, accidental: .flat)
+    static let Eb = NoteClass(.E, accidental: .flat)
     /// E
-    static var E = NoteClass(.E)
+    static let E = NoteClass(.E)
     /// E♯
-    static var Es = NoteClass(.E, accidental: .sharp)
+    static let Es = NoteClass(.E, accidental: .sharp)
 
     /// F♭
-    static var Fb = NoteClass(.F, accidental: .flat)
+    static let Fb = NoteClass(.F, accidental: .flat)
     /// F
-    static var F = NoteClass(.F)
+    static let F = NoteClass(.F)
     /// F♯
-    static var Fs = NoteClass(.F, accidental: .sharp)
+    static let Fs = NoteClass(.F, accidental: .sharp)
 
     /// G♭
-    static var Gb = NoteClass(.G, accidental: .flat)
+    static let Gb = NoteClass(.G, accidental: .flat)
     /// G
-    static var G = NoteClass(.G)
+    static let G = NoteClass(.G)
     /// G♯
-    static var Gs = NoteClass(.G, accidental: .sharp)
+    static let Gs = NoteClass(.G, accidental: .sharp)
 
     /// A♭
-    static var Ab = NoteClass(.A, accidental: .flat)
+    static let Ab = NoteClass(.A, accidental: .flat)
     /// A
-    static var A = NoteClass(.A)
+    static let A = NoteClass(.A)
     /// A♯
-    static var As = NoteClass(.A, accidental: .sharp)
+    static let As = NoteClass(.A, accidental: .sharp)
 
     /// B♭
-    static var Bb = NoteClass(.B, accidental: .flat)
+    static let Bb = NoteClass(.B, accidental: .flat)
     /// B
-    static var B = NoteClass(.B)
+    static let B = NoteClass(.B)
     /// B♯
-    static var Bs = NoteClass(.B, accidental: .sharp)
+    static let Bs = NoteClass(.B, accidental: .sharp)
 }

--- a/Sources/Tonic/NoteClass.swift
+++ b/Sources/Tonic/NoteClass.swift
@@ -5,7 +5,7 @@ import Foundation
 public typealias NoteClassSet = BitSetAdapter<NoteClass, BitSet64>
 
 /// A note letter and accidental which spell a note. This leaves out the octave of the note.
-public struct NoteClass: Equatable, Hashable, Codable {
+public struct NoteClass: Sendable, Equatable, Hashable, Codable {
     /// Letter of the note class
     public var letter: Letter
 

--- a/Sources/Tonic/Octave.swift
+++ b/Sources/Tonic/Octave.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Private Octave enumeration for octave related functions
 /// Will make it public once the entirety of Tonic uses it well
-enum Octave: Int {
+enum Octave: Int, Sendable {
     case negative2 = -2
     case negative1 = -1
     case zero = 0

--- a/Sources/Tonic/Pitch.swift
+++ b/Sources/Tonic/Pitch.swift
@@ -61,7 +61,7 @@ public extension PitchSet {
 ///
 /// We want to use a notion of pitch that lends itself to combinatorial algorithms,
 /// as opposed to using e.g. a fundamental frequency.
-public struct Pitch: Equatable, Hashable, Codable {
+public struct Pitch: Sendable, Equatable, Hashable, Codable {
     /// MIDI Note Number 0-127
     public var midiNoteNumber: Int8
 

--- a/Sources/Tonic/PitchColor.swift
+++ b/Sources/Tonic/PitchColor.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 /// Pitch represented as color.
 ///
 /// Source: http://theappendix.net/posts/2013/08/music-and-color-the-french-connection
-public struct PitchColor {
+public struct PitchColor: Sendable {
 
     /// Pitch represented as color by Sir Isaac Newton 1704 and filled in by D.D. James 1844
     public static var newtonian: [CGColor] {

--- a/Sources/Tonic/Scale.swift
+++ b/Sources/Tonic/Scale.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// A set of intervals from the root (tonic).
-public struct Scale: OptionSet, Hashable {
+public struct Scale: OptionSet, Sendable, Hashable {
     public let rawValue: Int
 
     public let description: String


### PR DESCRIPTION
- I added `Hashable` conformances to all of `Tonic`'s types, except for `ChordTable` and `PitchColor`.
- I added `Sendable` conformances to all of `Tonic`'s types, except for `ChordTable`.
- I changed static properties (described as "shortcuts") for `Note`, `Chord`, and `NoteClass` from `static var` (mutable static property) to `static let` (immutable static constants). This ensures that they're concurrency-safe, as they're not mutable.

This relates to my own pull requests #54 and #55.