### PR TITLE
Bugfix: Clamp Note.noteNumber to MIDI range (0-127) to prevent crashes

### DIFF
--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -82,19 +82,33 @@ public struct Note: Sendable, Equatable, Hashable, Codable {
 
     /// MIDI Note 0-127 starting at C
     public var noteNumber: Int8 {
-        let octaveBounds = ((octave + 2) * 12) ... ((octave + 3) * 12)
-        var note = Int(noteClass.letter.baseNote) + Int(noteClass.accidental.rawValue)
-        if noteClass.letter == .B && noteClass.accidental.rawValue > 0 {
-            note -= 12
-        }
-        if noteClass.letter == .C && noteClass.accidental.rawValue < 0 {
-            note += 12
-        }
-        while !octaveBounds.contains(note) {
-            note += 12
-        }
-        return Int8(note)
-    }
+         if octave < -2 {
+             return 0
+         }
+         if octave > 8 {
+             return 127
+         }
+         
+         let octaveBounds = ((octave + 2) * 12) ... ((octave + 3) * 12)
+         var note = Int(noteClass.letter.baseNote) + Int(noteClass.accidental.rawValue)
+         if noteClass.letter == .B && noteClass.accidental.rawValue > 0 {
+             note -= 12
+         }
+         if noteClass.letter == .C && noteClass.accidental.rawValue < 0 {
+             note += 12
+         }
+         while !octaveBounds.contains(note) {
+             note += 12
+         }
+         
+         if note < 0 {
+             return 0
+         }
+         if note > 127 {
+             return 127
+         }
+         return Int8(note)
+     }
 
     /// The pitch for the note
     public var pitch: Pitch {

--- a/Sources/Tonic/Note.swift
+++ b/Sources/Tonic/Note.swift
@@ -88,7 +88,6 @@ public struct Note: Sendable, Equatable, Hashable, Codable {
          if octave > 8 {
              return 127
          }
-         
          let octaveBounds = ((octave + 2) * 12) ... ((octave + 3) * 12)
          var note = Int(noteClass.letter.baseNote) + Int(noteClass.accidental.rawValue)
          if noteClass.letter == .B && noteClass.accidental.rawValue > 0 {
@@ -100,7 +99,6 @@ public struct Note: Sendable, Equatable, Hashable, Codable {
          while !octaveBounds.contains(note) {
              note += 12
          }
-         
          if note < 0 {
              return 0
          }

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -162,9 +162,8 @@ final class NoteTests: XCTestCase {
         let empty = NoteSet()
         XCTAssertNil(empty.first)
     }
-    
-    func testClampNoteBounds() {
 
+    func testClampNoteBounds() {
        let bMinus3 = Note(.B, octave: -3)
        XCTAssertEqual(bMinus3.noteNumber, 0)
        

--- a/Tests/TonicTests/NoteTests.swift
+++ b/Tests/TonicTests/NoteTests.swift
@@ -162,4 +162,22 @@ final class NoteTests: XCTestCase {
         let empty = NoteSet()
         XCTAssertNil(empty.first)
     }
+    
+    func testClampNoteBounds() {
+
+       let bMinus3 = Note(.B, octave: -3)
+       XCTAssertEqual(bMinus3.noteNumber, 0)
+       
+       let cFlatMinus3 = Note(.C, accidental: .flat, octave: -3)
+       XCTAssertEqual(cFlatMinus3.noteNumber, 0)
+       
+       let a8 = Note(.A, octave: 8)
+       XCTAssertEqual(a8.noteNumber, 127)
+       
+       let gSharp8 = Note(.G, accidental: .sharp, octave: 8)
+       XCTAssertEqual(gSharp8.noteNumber, 127)
+       
+       let c9 = Note(.C, octave: 9)
+       XCTAssertEqual(c9.noteNumber, 127)
+   }
 }


### PR DESCRIPTION
It is possible to create instances of the Note struct that represent values outside of the 0-127 MIDI note range. In such a case, accessing the Note.noteNumber calculated property may result in either an infinite loop or a crash. If the octave is set to less than -2, the following gets stuck in an infinite loop:
```
 while !octaveBounds.contains(note) {
             note += 12
}
```
Also, if the final calculated note value is greater than 127, it will cause a crash when being cast to Int8 prior to being returned.

The fix:
- Add early bounds checking for octave values outside -2 to 8 range. This fixes the infinite loop.
- Add final bounds checking to ensure note values are within MIDI range. Prevents crash when casting to Int8.
- Add test to NoteTests.